### PR TITLE
Revert "fix: change to `executeScript` in service.test.ts to resolve CI failures"

### DIFF
--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -11,7 +11,7 @@ vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdi
 
 const browser = {
     config: {},
-    executeScript: vi.fn(),
+    execute: vi.fn(),
     chromeA: { sessionId: 'sessionChromeA' },
     chromeB: { sessionId: 'sessionChromeB' },
     chromeC: { sessionId: 'sessionChromeC' },


### PR DESCRIPTION
Reverts LambdaTest/wdio-lambdatest-service#100